### PR TITLE
Update wp-requirements.php

### DIFF
--- a/src/wp-requirements.php
+++ b/src/wp-requirements.php
@@ -92,7 +92,7 @@ if ( ! class_exists( 'WP_Requirements' ) ) {
 		 */
 		public function __construct( $name, $plugin, $requirements ) {
 
-			$this->name = htmlspecialchars( strip_tags( $name ) );
+			$this->name = esc_html( wp_strip_all_tags( $name ) );
 			$this->plugin = $plugin;
 			$this->requirements = $requirements;
 


### PR DESCRIPTION
wp_strip_all_tags strip everything even scripts and styles, and esc_html perform a more complete escape for html entities.
